### PR TITLE
Add partial calc_ha_dec_rad methods.

### DIFF
--- a/include/radiointerferometryc99.h
+++ b/include/radiointerferometryc99.h
@@ -5,6 +5,7 @@
 #include <math.h>
 #include "_geodesy.h"
 #include "erfa.h"
+#include "erfam.h"
 
 #define DAYSEC ERFA_DAYSEC
 
@@ -46,6 +47,23 @@ float calc_hypotenuse_f(float* position, int dims);
 double calc_hypotenuse(double* position, int dims);
 
 void calc_frame_translate(double* positions, int position_count, double translation[3]);
+
+void calc_ha_dec_rad_a(
+	double longitude_rad,
+	double latitude_rad,
+	double altitude,
+	double timemjd,
+	double dut1,
+    eraASTROM* astrom
+);
+
+void calc_ha_dec_rad_b(
+	double ra_rad,
+	double dec_rad,
+    eraASTROM* astrom,
+	double* hour_angle_rad,
+	double* declination_rad
+);
 
 void calc_ecef_from_lla(
 	double ecef[3],

--- a/src/radiointerferometryc99.c
+++ b/src/radiointerferometryc99.c
@@ -16,6 +16,49 @@ float calc_julian_date_from_guppi_param(
 	 return calc_julian_date_from_unix(synctime + tperpktidx*pktidx);
 }
 
+void calc_ha_dec_rad_a(
+	double longitude_rad,
+	double latitude_rad,
+	double altitude,
+	double timemjd,
+	double dut1,
+    eraASTROM* astrom
+) {
+	double eo;
+    eraApco13(
+        timemjd, 0,
+        dut1,
+        longitude_rad, latitude_rad, altitude,
+        0, 0,
+        0, 0, 0, 0,
+        astrom,
+        &eo
+    );
+}
+
+void calc_ha_dec_rad_b(
+	double ra_rad,
+	double dec_rad,
+    eraASTROM* astrom,
+	double* hour_angle_rad,
+	double* declination_rad
+) {
+	double aob, zob, rob, ri, di;
+    eraAtciq(
+        ra_rad, dec_rad,
+        0, 0, 0, 0,
+        astrom,
+        &ri, &di
+    );
+    eraAtioq(
+        ri, di,
+        astrom,
+        &aob, &zob,
+        hour_angle_rad, declination_rad,
+        &rob
+    );
+}
+
 void calc_ha_dec_rad(
 	double ra_rad,
 	double dec_rad,
@@ -37,7 +80,7 @@ void calc_ha_dec_rad(
 		0, 0,
 		0, 0, 0, 0,
 		&aob, &zob, hour_angle_rad,
-    declination_rad, &rob, &eo
+        declination_rad, &rob, &eo
 	);
 }
 


### PR DESCRIPTION
This pull-request adds `calc_ha_dec_rad_a` and `calc_ha_dec_rad_b` methods making possible to cache the ASTROM data for multiple beams.